### PR TITLE
Add authorization check to "get question" web API

### DIFF
--- a/src/Tailspin.Surveys.Data/DataStore/SqlServerQuestionStore.cs
+++ b/src/Tailspin.Surveys.Data/DataStore/SqlServerQuestionStore.cs
@@ -19,6 +19,7 @@ namespace Tailspin.Surveys.Data.DataStore
        public async Task<Question> GetQuestionAsync(int id)
         {
             return await _dbContext.Questions
+                .Include(q => q.Survey)
                 .SingleOrDefaultAsync(q => q.Id == id)
                 .ConfigureAwait(false);
         }

--- a/src/Tailspin.Surveys.Web/Controllers/SurveyController.cs
+++ b/src/Tailspin.Surveys.Web/Controllers/SurveyController.cs
@@ -15,6 +15,7 @@ using Tailspin.Surveys.Security.Policy;
 using Tailspin.Surveys.Web.Logging;
 using Tailspin.Surveys.Web.Models;
 using Tailspin.Surveys.Web.Services;
+using Microsoft.AspNet.Authentication.Cookies;
 
 namespace Tailspin.Surveys.Web.Controllers
 {
@@ -617,7 +618,8 @@ namespace Tailspin.Surveys.Web.Controllers
 
             if (result.StatusCode == (int) HttpStatusCode.Forbidden)
             {
-                return RedirectToAction("Forbidden", "Home");
+                // Redirects user to Forbidden page
+                return new ChallengeResult(CookieAuthenticationDefaults.AuthenticationScheme);
             }
 
             if (result.StatusCode == (int) HttpStatusCode.NotFound)

--- a/src/Tailspin.Surveys.WebAPI/Controllers/QuestionController.cs
+++ b/src/Tailspin.Surveys.WebAPI/Controllers/QuestionController.cs
@@ -10,7 +10,6 @@ using Tailspin.Surveys.Data.DataStore;
 using Tailspin.Surveys.Data.DTOs;
 using Tailspin.Surveys.Security.Policy;
 
-
 namespace Tailspin.Surveys.WebAPI.Controllers
 {
     /// <summary>
@@ -45,6 +44,12 @@ namespace Tailspin.Surveys.WebAPI.Controllers
                 //Logger.LogInformation("Details: Item not found {0}", id);
                 return HttpNotFound();
             }
+
+            if (!await _authorizationService.AuthorizeAsync(User, question.Survey, Operations.Update))
+            {
+                return new HttpStatusCodeResult((int)HttpStatusCode.Forbidden);
+            }
+
             return new ObjectResult(DataMapping._questionToDto(question));
         }
 
@@ -115,13 +120,7 @@ namespace Tailspin.Surveys.WebAPI.Controllers
                 return HttpNotFound();
             }
 
-            var survey = await _surveyStore.GetSurveyAsync(question.SurveyId);
-            if (survey == null)
-            {
-                return HttpNotFound();
-            }
-
-            if (!await _authorizationService.AuthorizeAsync(User, survey, Operations.Update))
+            if (!await _authorizationService.AuthorizeAsync(User, question.Survey, Operations.Update))
             {
                 return new HttpStatusCodeResult((int)HttpStatusCode.Forbidden);
             }
@@ -153,13 +152,7 @@ namespace Tailspin.Surveys.WebAPI.Controllers
                 return HttpNotFound();
             }
 
-            var survey = await _surveyStore.GetSurveyAsync(question.SurveyId);
-            if (survey == null)
-            {
-                return HttpNotFound();
-            }
-
-            if (!await _authorizationService.AuthorizeAsync(User, survey, Operations.Update))
+            if (!await _authorizationService.AuthorizeAsync(User, question.Survey, Operations.Update))
             {
                 return new HttpStatusCodeResult((int)HttpStatusCode.Forbidden);
             }


### PR DESCRIPTION
- In `Tailspin.Surveys.WebAPI.Controllers.QuestionController.cs`, add an authorization check to the Get method.
- In `Tailspin.Surveys.Web.Controllers.QuestionController`, handle API errors the same way as the SurveyController
- In `SqlServerQuestionStore`, use EF Include to get the Survey navigation property.
- In `Tailspin.Surveys.Web.Controllers.SurveyController`, return `ChallengeResult` to redirect to Forbidden page