### PR TITLE
Log HTTP response status code as int

### DIFF
--- a/src/Tailspin.Surveys.Web/Logging/HttpClientLogHandler.cs
+++ b/src/Tailspin.Surveys.Web/Logging/HttpClientLogHandler.cs
@@ -53,7 +53,7 @@ namespace Tailspin.Surveys.Web.Logging
             }
             else
             {
-                _logger.RequestFailed(method, uri, requestStopwatch.Elapsed, response.ReasonPhrase, response.StatusCode.ToString(), userId, issuerValue);
+                _logger.RequestFailed(method, uri, requestStopwatch.Elapsed, response.ReasonPhrase, (int)response.StatusCode, userId, issuerValue);
 
             }
             return response;

--- a/src/Tailspin.Surveys.Web/Logging/WebApiCallsLoggingExtensions.cs
+++ b/src/Tailspin.Surveys.Web/Logging/WebApiCallsLoggingExtensions.cs
@@ -17,7 +17,7 @@ namespace Tailspin.Surveys.Web.Logging
             logger.LogInformation("Request succeeded to web api Uri: {0} Method: {1} Elapsed Time: {2}ms user: {3} of issuer: {4}", uri, method, elapsedTime.TotalMilliseconds, userId, issuer);
         }
 
-        public static void RequestFailed(this ILogger logger, string method, string uri, TimeSpan elapsedTime, string reasonPhrase, string statusCode, string userId, string issuer)
+        public static void RequestFailed(this ILogger logger, string method, string uri, TimeSpan elapsedTime, string reasonPhrase, int statusCode, string userId, string issuer)
         {
             logger.LogError("Request failed to web api Uri:{0} Method: {1} Reason: {2} StatusCode {3} Elapsed Time: {4}ms user: {5} of issuer: {6}", uri, method, reasonPhrase, statusCode, elapsedTime.TotalMilliseconds, userId, issuer);
         }


### PR DESCRIPTION
When we log HTTP errors, the status code is formatted like this:

    Method: GET Reason: Unauthorized StatusCode Unauthorized

That makes it hard to search for known status codes (e.g. 401 or 403) in the
logs. This commit changes the output to:

    Method: GET Reason: Unauthorized StatusCode 401