### PR TITLE
Use default authentication scheme name in web api

### DIFF
--- a/src/Tailspin.Surveys.WebAPI/Controllers/QuestionController.cs
+++ b/src/Tailspin.Surveys.WebAPI/Controllers/QuestionController.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Authentication.JwtBearer;
 using Microsoft.AspNet.Authorization;
 using Microsoft.AspNet.Mvc;
 using Tailspin.Surveys.Data.DataModels;
@@ -16,7 +17,7 @@ namespace Tailspin.Surveys.WebAPI.Controllers
     /// This class provides a REST based API for the management of questions.
     /// This class uses Bearer token authentication and authorization.
     /// </summary>
-    [Authorize(ActiveAuthenticationSchemes = "Bearer")]
+    [Authorize(ActiveAuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     public class QuestionController : Controller
     {
         private readonly IQuestionStore _questionStore;

--- a/src/Tailspin.Surveys.WebAPI/Controllers/SurveyController.cs
+++ b/src/Tailspin.Surveys.WebAPI/Controllers/SurveyController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Authentication.JwtBearer;
 using Microsoft.AspNet.Authorization;
 using Microsoft.AspNet.Mvc;
 using Tailspin.Surveys.Data.DataModels;
@@ -18,7 +19,7 @@ namespace Tailspin.Surveys.WebAPI.Controllers
     /// This class provides a REST based API for the management of surveys.
     /// This class uses Bearer token authentication and authorization.
     /// </summary>
-    [Authorize(ActiveAuthenticationSchemes = "Bearer")]
+    [Authorize(ActiveAuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     public class SurveyController : Controller
     {
         private readonly ISurveyStore _surveyStore;

--- a/src/Tailspin.Surveys.WebAPI/Startup.cs
+++ b/src/Tailspin.Surveys.WebAPI/Startup.cs
@@ -3,6 +3,7 @@
 
 using System; //Needed for KeyVaultConfigurationProvider
 using System.IdentityModel.Tokens;
+using Microsoft.AspNet.Authentication.JwtBearer;
 using Microsoft.AspNet.Authorization;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Diagnostics;
@@ -68,13 +69,13 @@ namespace Tailspin.Surveys.WebApi
                     policy =>
                     {
                         policy.AddRequirements(new SurveyCreatorRequirement());
-                        policy.AddAuthenticationSchemes("Bearer");
+                        policy.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme);
                     });
                 options.AddPolicy(PolicyNames.RequireSurveyAdmin,
                     policy =>
                     {
                         policy.AddRequirements(new SurveyAdminRequirement());
-                        policy.AddAuthenticationSchemes("Bearer");
+                        policy.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme);
                     });
             });
 


### PR DESCRIPTION
We register the JWT Bearer authentication middleware using the default
authentication scheme name, which is defined by the constant
`JwtBearerDefaults.AuthenticationScheme`.

Since we're not overriding the default, we should use this const
instead of a string literal in the authZ policies and `[Authorize]`.

(We already do the equivalent in the web app.)