### PR TITLE
Fall back to empty SecretItem list

### DIFF
--- a/src/Tailspin.Surveys.Configuration.KeyVault/KeyVaultConfigurationProvider.cs
+++ b/src/Tailspin.Surveys.Configuration.KeyVault/KeyVaultConfigurationProvider.cs
@@ -108,7 +108,7 @@ namespace Tailspin.Surveys.Configuration.KeyVault
             // This returns a list of identifiers which are uris to the secret, you need to use the identifier to get the actual secrets again.
             var kvClient = new KeyVaultClient(GetTokenAsync);
             var secretsResponseList = await kvClient.GetSecretsAsync(_vault, MaxSecrets, token);
-            foreach (var secretItem in secretsResponseList.Value)
+            foreach (var secretItem in secretsResponseList.Value ?? new List<SecretItem>())
             {
                 //The actual config key is stored in a tag with the Key "ConfigKey" since : is not supported in a shared secret name by KeyVault
                 if (secretItem.Tags != null && secretItem.Tags.ContainsKey(ConfigKey))


### PR DESCRIPTION
In some cases `KeyVaultClient.GetSecretsAsync` can return a null
collection instead of an empty collection. This fix handles that case.

Note: This only seems to happen if you create a new KeyVault without
adding any secrets to it. If you add a secret and then delete it,
`KeyVaultClient` returns an empty collection.