### PR TITLE
Question on clearing Token Cache on SignOut

### DIFF
--- a/src/Tailspin.Surveys.Web/Security/SignInManager.cs
+++ b/src/Tailspin.Surveys.Web/Security/SignInManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -19,8 +18,6 @@ namespace Tailspin.Surveys.Web.Security
     {
         private readonly HttpContext _httpContext;
 
-        private readonly ISurveysTokenService _surveysTokenService;
-
         private readonly ILogger _logger;
 
         /// <summary>
@@ -30,16 +27,14 @@ namespace Tailspin.Surveys.Web.Security
         /// <param name="surveysTokenService">An instance of <see cref="Tailspin.Surveys.Web.Security.ISurveysTokenService"/></param>
         /// <param name="logger">An <see cref="Microsoft.Extensions.Logging.ILogger"/> implementation used for diagnostic information.</param>
         public SignInManager(IHttpContextAccessor contextAccessor,
-            ISurveysTokenService surveysTokenService,
             ILogger<SignInManager> logger)
         {
             _httpContext = contextAccessor.HttpContext;
-            _surveysTokenService = surveysTokenService;
             _logger = logger;
         }
 
         /// <summary>
-        /// Signs the currently signed in principal out of all authentication schemes and clears any access tokens from the token cache.
+        /// Signs the currently signed in principal out of all authentication schemes.
         /// </summary>
         /// <param name="redirectUrl">A Url to which the user should be redirected when sign out of AAD completes.</param>
         /// <returns>A <see cref="System.Threading.Tasks.Task{Microsoft.AspNetCore.Mvc.IActionResult}"/> implementation.</returns>


### PR DESCRIPTION
While implementing logout functionality for something I'm working on, I tried to figure out exactly how the distributed token cache was cleared on logout. The comment for `SignOutAsync` mentioned that it cleared the cache but I don't think that's the case. This functionality was removed in https://github.com/mspnp/multitenant-saas-guidance/commit/a88783a5342b2e5a258dfcadf7ac75fcc8937f09. I've updated the comment here and I've also got a question.

**Is there a reason to clear (or not clear) the token cache on sign out?** I wasn't able to find anything to answer this question anywhere else. If the user is fully logged out (hits `https://login.windows.net/{tenantId}/oauth2/logout`) will this token that's still in the token cache still be valid on a subsequent login? 

If yes, then I would understand why not clearing the cache might be good. This could potentially speed up the login process the next time around (if the token hasn't expired, at least)
If no, then does that make the login process longer? I haven't found anywhere that the token itself is actually validated. Is there a chance that an operation might fail using an invalid token that was pulled from the token cache?

The only place where the token cache is explicitly cleared (in this repo) is here: https://github.com/mspnp/multitenant-saas-guidance/blob/master/src/Tailspin.Surveys.Web/Security/SurveyAuthenticationEvents.cs#L270

There is another sample in another repo which _does_ explicitly clear the token cache on sign out: https://github.com/Azure-Samples/active-directory-dotnet-webapp-webapi-openidconnect/blob/master/TodoListWebApp/Controllers/AccountController.cs#L50
Here's another sample which _does not_ clear the token cache on sign out:
https://github.com/aspnet/Security/blob/dev/samples/OpenIdConnect.AzureAdSample/Startup.cs#L107-L111

Relevant documentation I've checked: 
https://github.com/Azure-Samples/active-directory-dotnet-webapp-openidconnect-aspnetcore
https://docs.microsoft.com/en-us/azure/architecture/multitenant-identity/token-cache
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet