### PR TITLE
Fix missing parameters on pwsh script

### DIFF
--- a/scripts/Setup-KeyVault.ps1
+++ b/scripts/Setup-KeyVault.ps1
@@ -14,7 +14,13 @@
 [parameter(Mandatory=$false, ParameterSetName="GenerateCertificate")]
 [ValidateScript({if ($_){ Test-Path $_ -PathType Container }})][string]$OutputPath,
 
+[parameter(Mandatory=$true, ParameterSetName="SetAccessPolicy")]
 [parameter(Mandatory=$true, ParameterSetName="CreateKeyVault")]
+[string]$SubscriptionId,
+
+[parameter(Mandatory=$true, ParameterSetName="SetAccessPolicy")]
+[parameter(Mandatory=$true, ParameterSetName="CreateKeyVault")]
+[parameter(Mandatory=$true, ParameterSetName="SetConfigValue")]
 [string]$ResourceGroupName,
 
 [parameter(Mandatory=$true, ParameterSetName="CreateKeyVault")]
@@ -77,7 +83,7 @@ param(
 [parameter(Mandatory=$true, ValueFromPipeline=$true)]$ApplicationId
 )
     process {
-        Set-AzureRmKeyVaultAccessPolicy -VaultName $KeyVaultName -ServicePrincipalName $ApplicationId -PermissionsToSecrets get,list -ErrorAction Stop
+        Set-AzureRmKeyVaultAccessPolicy -VaultName $KeyVaultName -ResourceGroupName $ResourceGroupName -ServicePrincipalName $ApplicationId -PermissionsToSecrets get,list -ErrorAction Stop
     }
 }
 
@@ -113,12 +119,16 @@ switch($PSCmdlet.ParameterSetName)
     "CreateKeyVault"
     {
         Login-AzureRmAccount
+        Select-AzureRmSubscription -Subscription $SubscriptionId
+
         New-AzureRmResourceGroup –Name $ResourceGroupName –Location $Location -ErrorAction Stop
         New-AzureRmKeyVault -VaultName $KeyVaultName -ResourceGroupName $ResourceGroupName -Location $Location -ErrorAction Stop
     }
     "SetAccessPolicy"
     {
         Login-AzureRmAccount
+        Select-AzureRmSubscription -Subscription $SubscriptionId
+
         # Set the access policy for the ApplicationIds
         $ApplicationIds.GetEnumerator() | Set-AccessPolicy
     }
@@ -130,6 +140,7 @@ switch($PSCmdlet.ParameterSetName)
         Validate-ValueParameter $KeyValueObject
         #Everything is good, so login to AzureRM
         Login-AzureRmAccount
+        Select-AzureRmSubscription -Subscription $SubscriptionId
         #Setup secrets
         Set-KeyVaultSecret $KeyValueObject
     }

--- a/scripts/Setup-KeyVault.ps1
+++ b/scripts/Setup-KeyVault.ps1
@@ -16,6 +16,7 @@
 
 [parameter(Mandatory=$true, ParameterSetName="SetAccessPolicy")]
 [parameter(Mandatory=$true, ParameterSetName="CreateKeyVault")]
+[parameter(Mandatory=$true, ParameterSetName="SetConfigValue")]
 [string]$SubscriptionId,
 
 [parameter(Mandatory=$true, ParameterSetName="SetAccessPolicy")]


### PR DESCRIPTION
Hi,

I was following [this guidance](https://docs.microsoft.com/en-us/azure/architecture/multitenant-identity/key-vault) and I could not use the script [scripts/Setup-KeyVault.ps1](scripts/Setup-KeyVault.ps1) because of two reasons:

- We need the `ResourceGroupName` to run the command below:

```powershell
Set-AzureRmKeyVaultAccessPolicy
```

- For people who have multiple Azure Subscriptions, we need to select it right after we logged in to Azure using `Login-AzureRMAccount`. That's why I added the `SubscriptionId` parameter to:
  - `SetAccessPolicy`
  - `CreateKeyVault`

I'm creating a PR on the [architecture center](https://github.com/MicrosoftDocs/architecture-center/blob/master/docs/multitenant-identity/key-vault.md) repo as well to update the guidance for calling this script.